### PR TITLE
Fix landscape setting and icon

### DIFF
--- a/refresh_template.sh
+++ b/refresh_template.sh
@@ -41,11 +41,13 @@ for templatefile in *.png ; do
     printf "\n\t,{">> $current_file
     printf "\t\t\"name\": \"%s\",\n" "$name"  >> $current_file
     printf "\t\t\"filename\": \"%s\",\n" "$name"  >> $current_file
-    printf "\t\t\"iconCode\": \"%s\",\n" "\\ue9fe"  >> $current_file
 
     #Adding landscape = true if LS is in the name (case sensitive)
     if [[ $name = *"LS"* ]]; then
-        printf "\t\t\"landscape\": \"%s\",\n" "true"  >> $current_file
+	printf "\t\t\"iconCode\": \"%s\",\n" "\\ue9fd"  >> $current_file
+	printf "\t\t\"landscape\": true,\n" >> $current_file
+    else
+	printf "\t\t\"iconCode\": \"%s\",\n" "\\ue9fe"  >> $current_file
     fi
 
     #Tagging to custom cateogry


### PR DESCRIPTION
There's a landscape-oriented blank icon (`e9fd` vs `e9fe`) so I used that when the filename contains `LS`.

Also, I'm pretty sure the JSON `landscape` attribute should be a bare `true` rather than `"true"` (boolean vs string). Before this change, although the landscape templates would show up under landscape in the template selector, once I selected one, my tablet reoriented the toolbar into portrait mode. This keeps it in landscape mode. (I have software version 2.1.1.3.)

Thanks!