### PR TITLE
Allow template script to be run anywhere.

### DIFF
--- a/refresh_template.sh
+++ b/refresh_template.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd /usr/share/remarkable/templates/
+
 #md5sum of templates.json version 1.4.0.7
 original_md5=0e7d0b7175e8d99028e0b66756f27f08
 original_file="templates.json.original"


### PR DESCRIPTION
Instead of having to put the script in `/usr/share/remarkable/templates/`, have the script change its working directory. This way it can be run from anywhere on the tablet. (I keep mine in the root home folder.)